### PR TITLE
Fix description in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_status
 version: 0.1.1
-description: A new flutter plugin project.
+description: A flutter plugin to check the device connectivity.
 author: Erick Ghaumez <erick@rxla.bz>
 homepage: https://github.com/rxlabz/connectivity_status
 


### PR DESCRIPTION
This string shows up on pub:

![image](https://user-images.githubusercontent.com/1227763/26855631-00cc6cbc-4ad1-11e7-8466-b4c7ca05b628.png)
